### PR TITLE
Create Astro base layout and homepage

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,0 +1,38 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+}
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+.hero p {
+  font-size: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+.btn {
+  background-color: #0070f3;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  text-decoration: none;
+  display: inline-block;
+}
+.services {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding: 2rem;
+}
+.service {
+  text-align: center;
+}
+footer {
+  text-align: center;
+  padding: 2rem 0;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('Astro funcionando');
+});

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,15 @@
+---
+---
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/main.css" />
+    <script src="/js/app.js" defer></script>
+    <title><slot name="title">Astro</slot></title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,29 @@
 ---
-import Welcome from '../components/Welcome.astro';
-import Layout from '../layouts/Layout.astro';
-
-// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
-// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
+import Base from '../layouts/Base.astro';
+const services = [
+  { icon: '💻', title: 'Desarrollo Web', desc: 'Sitios modernos y rápidos.' },
+  { icon: '📱', title: 'Aplicaciones Móviles', desc: 'Apps nativas para iOS y Android.' },
+  { icon: '☁️', title: 'Servicios en la nube', desc: 'Infraestructura escalable.' }
+];
 ---
+<Base>
+  <section class="hero">
+    <h1>Bienvenido a Astro</h1>
+    <p>Desarrolla sitios más rápidos con menos JavaScript.</p>
+    <a href="#" class="btn">Comienza ahora</a>
+  </section>
 
-<Layout>
-	<Welcome />
-</Layout>
+  <section class="services">
+    {services.map(service => (
+      <div class="service">
+        <div class="icon">{service.icon}</div>
+        <h3>{service.title}</h3>
+        <p>{service.desc}</p>
+      </div>
+    ))}
+  </section>
+
+  <footer>
+    <p>&copy; {new Date().getFullYear()} Mi sitio</p>
+  </footer>
+</Base>


### PR DESCRIPTION
## Summary
- add Base layout that links public CSS and JS
- build index page with hero, services grid, and footer
- include basic styles and console logging script

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: sh: 1: astro: not found)

------
https://chatgpt.com/codex/tasks/task_b_68b83b1e4ef483218ecd53696146d1f8